### PR TITLE
Add shortcake support to shortcode module

### DIFF
--- a/bea-plugin-boilerplate.php
+++ b/bea-plugin-boilerplate.php
@@ -2,7 +2,7 @@
 /*
  Plugin Name: BEA Plugin Name
  Version: 1.0.0
- Version Boilerplate: 2.1.3
+ Version Boilerplate: 2.2.0
  Plugin URI: http://www.beapi.fr
  Description: Your plugin description
  Author: BE API Technical team

--- a/classes/shortcodes/shortcode.php
+++ b/classes/shortcodes/shortcode.php
@@ -94,7 +94,6 @@ abstract class Shortcode {
 	 *
 	 * @since   2.2.0
 	 *
-	 * @param $tag
 	 * @param $args
 	 */
 	public function register_shortcode_ui( $args = array() ) {

--- a/classes/shortcodes/shortcode.php
+++ b/classes/shortcodes/shortcode.php
@@ -19,6 +19,8 @@ abstract class Shortcode {
 
 	/**
 	 * The shortcode [tag]
+	 *
+	 * @var string
 	 * @since   2.1.0
 	 */
 	protected $tag = '';
@@ -32,12 +34,24 @@ abstract class Shortcode {
 	protected $defaults = array();
 
 	/**
+	 * Flag to enable shortcake support
+	 *
+	 * @var bool
+	 * @since   2.2.0
+	 */
+	protected $shortcake_support = false;
+
+	/**
 	 * Create a shortcode
 	 *
 	 * @since   2.1.0
 	 */
 	public function add() {
 		add_shortcode( $this->tag, array( $this, 'render' ) );
+
+		if ( $this->shortcake_support ) {
+			$this->add_shortcake_support( );
+		}
 	}
 
 	/**
@@ -65,4 +79,35 @@ abstract class Shortcode {
 	 */
 	public abstract function render( $attributes = array(), $content = '' );
 
+
+	/**
+	 * Allow shortcake support
+	 * Just extend this method and call register_shortcode_ui function
+	 *
+	 * @since   2.2.0
+	 */
+	protected function add_shortcake_support( ) {}
+
+	/**
+	 * Register a UI for the Shortcode.
+	 * Pass an array or args.
+	 *
+	 * @since   2.2.0
+	 *
+	 * @param $tag
+	 * @param $args
+	 */
+	public function register_shortcode_ui( $args = array() ) {
+
+		if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+			return false;
+		}
+
+		shortcode_ui_register_for_shortcode(
+			$this->tag,
+			$args
+		);
+
+		return true;
+	}
 }


### PR DESCRIPTION
Usage :

In your extended shortcode, set shortcode_support flag to true :
	`protected $shortcake_support = true;`

Then call the add_shortcake_support function :
```php
<?php
	protected function add_shortcake_support() {
		$this->register_shortcode_ui( array(

			// Display label. String. Required.
			'label' => 'My Wonderfull Shortcode',

			// Icon/image for shortcode. Optional. src or dashicons-$icon. Defaults to carrot.
			'listItemImage' => 'dashicons-format-aside',

			// Available shortcode attributes and default values. Required. Array.
			// Attribute model expects 'attr', 'type' and 'label'
			// Supported field types: text, checkbox, textarea, radio, select, email, url, number, and date.
			'attrs' => array(
				array(
					'label'       => 'Note',
					'attr'        => 'desc',
					'type' => 'textarea',
					'description' => 'The text of the note',
				),
				array(
					'label'       => 'HTML Tag',
					'attr'        => 'tag',
					'type' => 'select',
					'options' => array(
						'span' => '<span>',
						'em' => '<em>',
						'strong' => '<strong>',
						'a' => '<a>',
					),
					'description' => 'Optional (<span> by default)',
				),
				array(
					'label'       => 'Link',
					'attr'        => 'link',
					'type' => 'url',
					'description' => 'The url of the link if you choose <a> tag',
				),
			),
			'inner_content' => array(
				'label' => 'Text',
			),
		) );
	}
```