### PR TITLE
implement `get_block_args` method in `Acf_Json_Block`

### DIFF
--- a/classes/Blocks/Acf_Block.php
+++ b/classes/Blocks/Acf_Block.php
@@ -77,7 +77,12 @@ abstract class Acf_Block implements Acf_Block_Interface {
 
 			$tpl = Helpers::load_template( 'template-admin-block-invalid' );
 			if ( ! empty( $tpl ) ) {
-				$tpl( [ 'block' => $block, 'error_messages' => $errors ] );
+				$tpl(
+					[
+						'block'          => $block,
+						'error_messages' => $errors,
+					]
+				);
 			}
 
 			return;

--- a/classes/Blocks/Acf_Json_Block.php
+++ b/classes/Blocks/Acf_Json_Block.php
@@ -26,4 +26,13 @@ abstract class Acf_Json_Block extends Acf_Block {
 			]
 		);
 	}
+
+	/**
+	 * Block registration args loaded from `block.json` file.
+	 *
+	 * @return array
+	 */
+	public function get_block_args(): array {
+		return [];
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,11 @@
   "config": {
     "optimize-autoloader": true,
     "preferred-install": { "*": "dist" },
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "phpro/grumphp-shim": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "v0.7.1",


### PR DESCRIPTION
When extending `Acf_Json_Block` class, block registration data are provided by the `block.json` file. The class implement the method to return an empty array.